### PR TITLE
Changing handler to work with singletons

### DIFF
--- a/src/MiniProfiler.Elasticsearch/MiniProfilerElasticsearch.cs
+++ b/src/MiniProfiler.Elasticsearch/MiniProfilerElasticsearch.cs
@@ -12,8 +12,8 @@
         /// Handles <see cref="IApiCallDetails"/> and pushes <see cref="CustomTiming"/> to current <see cref="MiniProfiler"/> session.
         /// </summary>
         /// <param name="apiCallDetails"><see cref="IApiCallDetails"/> to be handled.</param>
-        /// <param name="profiler">Current <see cref="MiniProfiler"/> session instance.</param>
-        internal static void HandleResponse(IApiCallDetails apiCallDetails, MiniProfiler profiler) {
+        internal static void HandleResponse(IApiCallDetails apiCallDetails) {
+            var profiler = MiniProfiler.Current;
             if (profiler == null || profiler.Head == null || apiCallDetails.DebugInformation == null) {
                 return;
             }

--- a/src/MiniProfiler.Elasticsearch/ProfiledElasticClient.cs
+++ b/src/MiniProfiler.Elasticsearch/ProfiledElasticClient.cs
@@ -6,8 +6,6 @@
     /// Profiled version of <see cref="ElasticClient"/>. Handles responses and pushes data to current <see cref="MiniProfiler"/>'s session.
     /// </summary>
     public class ProfiledElasticClient : ElasticClient {
-        private readonly MiniProfiler _profiler = MiniProfiler.Current;
-
         /// <summary>
         /// Provides base <see cref="ElasticClient"/> with profiling features to current <see cref="MiniProfiler"/> session.
         /// </summary>
@@ -16,7 +14,7 @@
             : base(configuration) {
             ProfilerUtils.ExcludeElasticsearchAssemblies();
             ProfilerUtils.ApplyConfigurationSettings(configuration);
-            configuration.OnRequestCompleted(apiCallDetails => MiniProfilerElasticsearch.HandleResponse(apiCallDetails, _profiler));
+            configuration.OnRequestCompleted(apiCallDetails => MiniProfilerElasticsearch.HandleResponse(apiCallDetails));
         }
     }
 }

--- a/src/MiniProfiler.Elasticsearch/ProfiledElasticsearchClient.cs
+++ b/src/MiniProfiler.Elasticsearch/ProfiledElasticsearchClient.cs
@@ -6,8 +6,6 @@
     /// Profiled version of <see cref="ElasticLowLevelClient"/>. Handles responses and pushes data to current <see cref="MiniProfiler"/>'s session.
     /// </summary>
     public class ProfiledElasticsearchClient : ElasticLowLevelClient {
-        private readonly MiniProfiler _profiler = MiniProfiler.Current;
-
         /// <summary>
         /// Provides base <see cref="ElasticLowLevelClient"/> with profiling features to current <see cref="MiniProfiler"/> session.
         /// </summary>
@@ -16,7 +14,7 @@
             : base(configuration) {
             ProfilerUtils.ExcludeElasticsearchAssemblies();
             ProfilerUtils.ApplyConfigurationSettings(configuration);
-            configuration.OnRequestCompleted(apiCallDetails => MiniProfilerElasticsearch.HandleResponse(apiCallDetails, _profiler));
+            configuration.OnRequestCompleted(apiCallDetails => MiniProfilerElasticsearch.HandleResponse(apiCallDetails));
         }
     }
 }


### PR DESCRIPTION
Given that the recommended lifetime of an `ElasticClient` is for it to be a singleton, I've changed / updated the handler to work with this.

Note: Sorry, I'm on linux and the whole project wouldn't build so I just took a stab at what sould be removed / addded etc.