### PR TITLE
DiagnosticListener integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ PM> Install-Package MiniProfiler.Elasticsearch
 | `6.x` | `6.x` | `4.x` | [![Build status](https://ci.appveyor.com/api/projects/status/m15gemuqkcs1rbv4/branch/master?svg=true)](https://ci.appveyor.com/project/romansp/miniprofiler-elasticsearch/branch/master) | [![Nuget feed](https://img.shields.io/nuget/vpre/MiniProfiler.Elasticsearch.svg)](https://www.nuget.org/packages/MiniProfiler.Elasticsearch)
 
 ## Usage
-Update usages of ``ElasticClient`` or ``ElasticsearchClient`` with their respected profiled version ``ProfiledElasticClient`` or ``ProfiledElasticsearchClient``.
+Update usages of ``ElasticClient`` or ``ElasticLowLevelClient`` with their respected profiled version ``ProfiledElasticClient`` or ``ProfiledElasticLowLevelClient``.
 
 Reference [Sample.Elasticsearch.Core](https://github.com/romansp/MiniProfiler.Elasticsearch/tree/master/samples/Sample.Elasticsearch.Core) for working example.

--- a/samples/Sample.Elasticsearch.Core/Sample.Elasticsearch.Core.csproj
+++ b/samples/Sample.Elasticsearch.Core/Sample.Elasticsearch.Core.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.2.22" />
-    <PackageReference Include="NEST" Version="7.11.1" />
+    <PackageReference Include="NEST" Version="7.12.1" />
   </ItemGroup>
 
 

--- a/samples/Sample.Elasticsearch.Core/Startup.cs
+++ b/samples/Sample.Elasticsearch.Core/Startup.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Nest;
 using StackExchange.Profiling;
-using StackExchange.Profiling.Elasticsearch;
 
 namespace Sample.Elasticsearch.Core {
     public class Startup {
@@ -17,14 +16,12 @@ namespace Sample.Elasticsearch.Core {
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services) {
             services.AddControllersWithViews();
+
+            // use AddElastic or wrap ElasticClient instance in ProfiledElasticClient
             services.AddMiniProfiler(options => options.AddElastic());
-            //services.AddMiniProfiler();
             services.AddSingleton<IElasticClient>(x => {
                 var node = new Uri("http://localhost:9200");
                 var connectionSettings = new ConnectionSettings(node).DefaultIndex("elasticsearch-sample");
-                connectionSettings.DisableDirectStreaming();
-                //connectionSettings.DisableDirectStreaming();
-                //return new ProfiledElasticClient(connectionSettings);
                 return new ElasticClient(connectionSettings);
             });
         }

--- a/samples/Sample.Elasticsearch.Core/Startup.cs
+++ b/samples/Sample.Elasticsearch.Core/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Nest;
+using StackExchange.Profiling;
 using StackExchange.Profiling.Elasticsearch;
 
 namespace Sample.Elasticsearch.Core {
@@ -16,11 +17,15 @@ namespace Sample.Elasticsearch.Core {
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services) {
             services.AddControllersWithViews();
-            services.AddMiniProfiler();
+            services.AddMiniProfiler(options => options.AddElastic());
+            //services.AddMiniProfiler();
             services.AddSingleton<IElasticClient>(x => {
                 var node = new Uri("http://localhost:9200");
                 var connectionSettings = new ConnectionSettings(node).DefaultIndex("elasticsearch-sample");
-                return new ProfiledElasticClient(connectionSettings);
+                connectionSettings.DisableDirectStreaming();
+                //connectionSettings.DisableDirectStreaming();
+                //return new ProfiledElasticClient(connectionSettings);
+                return new ElasticClient(connectionSettings);
             });
         }
 

--- a/src/MiniProfiler.Elasticsearch/ElasticDiagnosticListener.cs
+++ b/src/MiniProfiler.Elasticsearch/ElasticDiagnosticListener.cs
@@ -1,0 +1,101 @@
+﻿namespace StackExchange.Profiling.Elasticsearch {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using global::Elasticsearch.Net;
+    using global::Elasticsearch.Net.Diagnostics;
+    using StackExchange.Profiling.Internal;
+
+    /// <summary>
+    /// Diagnostic listener for Elasticsearch.Net events.
+    /// </summary>
+    public class ElasticDiagnosticListener : IObserver<DiagnosticListener>, IDisposable {
+        private bool disposedValue;
+        private ConcurrentBag<IDisposable> Disposables { get; } = new ConcurrentBag<IDisposable>();
+
+        /// <inheritdoc />
+        public void OnError(Exception error) => Trace.WriteLine(error);
+
+        /// <inheritdoc />
+        public bool Completed { get; private set; }
+
+        /// <inheritdoc />
+        public string ListenerName => DiagnosticSources.RequestPipeline.SourceName;
+
+        /// <inheritdoc />
+        public void OnCompleted() => Completed = true;
+
+        /// <inheritdoc />
+        public void OnNext(DiagnosticListener value) {
+            TrySubscribe(DiagnosticSources.AuditTrailEvents.SourceName,
+                () => new AuditDiagnosticObserver(v => WriteToProfiler(v.Key, v.Value)), value);
+
+            TrySubscribe(DiagnosticSources.Serializer.SourceName,
+                () => new SerializerDiagnosticObserver(v => WriteToProfiler(v.Key, v.Value)), value);
+
+            TrySubscribe(DiagnosticSources.RequestPipeline.SourceName,
+                () => new RequestPipelineDiagnosticObserver(
+                    v => WriteToProfiler(v.Key, v.Value),
+                    v => WriteToProfiler(v.Key, v.Value)
+                ), value);
+
+            TrySubscribe(DiagnosticSources.HttpConnection.SourceName,
+                () => new HttpConnectionDiagnosticObserver(
+                    v => WriteToProfiler(v.Key, v.Value),
+                    v => WriteToProfiler(v.Key, v.Value)
+                ), value);
+        }
+
+        public void OnNext(KeyValuePair<string, object> value) {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected virtual void Dispose(bool disposing) {
+            if (!disposedValue) {
+                if (disposing) {
+                    foreach (var d in Disposables) {
+                        d.Dispose();
+                    }
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose() {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void TrySubscribe(string sourceName, Func<IObserver<KeyValuePair<string, object?>>> listener, DiagnosticListener value) {
+            if (value.Name != sourceName) return;
+
+            var subscription = value.Subscribe(listener());
+            Disposables.Add(subscription);
+        }
+
+        private static void WriteToProfiler(string eventName, IApiCallDetails data) {
+            MiniProfilerElasticsearch.HandleResponse(data);
+        }
+
+        private static void WriteToProfiler(string eventName, Audit data) {
+            var profiler = MiniProfiler.Current;
+            if (profiler is null) return;
+
+            profiler.Head.AddCustomTiming("elasticsearch", new CustomTiming(profiler, data.Path) {
+                DurationMilliseconds = (decimal?)(data.Ended - data.Started).TotalMilliseconds,
+                ExecuteType = data.Event.GetStringValue(),
+            });
+        }
+
+        private static void WriteToProfiler<T>(string eventName, T data) {
+            var profiler = MiniProfiler.Current;
+            if (profiler is null) return;
+
+            //MiniProfilerElasticsearch.HandleResponse()
+        }
+    }
+}

--- a/src/MiniProfiler.Elasticsearch/MiniProfiler.Elasticsearch.csproj
+++ b/src/MiniProfiler.Elasticsearch/MiniProfiler.Elasticsearch.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="MiniProfiler.Shared" Version="4.*" />
-    <PackageReference Include="NEST" Version="7.11.1" />
+    <PackageReference Include="NEST" Version="7.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MiniProfiler.Elasticsearch/MiniProfiler.Elasticsearch.csproj
+++ b/src/MiniProfiler.Elasticsearch/MiniProfiler.Elasticsearch.csproj
@@ -16,9 +16,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
   </ItemGroup>
 </Project>

--- a/src/MiniProfiler.Elasticsearch/MiniProfilerBaseOptionsExtensions.cs
+++ b/src/MiniProfiler.Elasticsearch/MiniProfilerBaseOptionsExtensions.cs
@@ -1,19 +1,23 @@
 ﻿using System;
 using System.Diagnostics;
 using StackExchange.Profiling.Elasticsearch;
+using StackExchange.Profiling.Elasticsearch.Utils;
 using StackExchange.Profiling.Internal;
 
 namespace StackExchange.Profiling {
+
+    /// <summary>
+    /// Extension methods for the MiniProfiler.Elasticsearch.
+    /// </summary>
     public static class MiniProfilerBaseOptionsExtensions {
         /// <summary>
-        /// Adds Entity Framework Core profiling for MiniProfiler via DiagnosticListener.
+        /// Adds Elastic profiling for MiniProfiler via DiagnosticListener.
         /// </summary>
         /// <typeparam name="T">The specific options type to chain with.</typeparam>
         /// <param name="options">The <see cref="MiniProfilerBaseOptions" /> to register on (just for chaining).</param>
         /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
         public static T AddElastic<T>(this T options) where T : MiniProfilerBaseOptions {
-            //var initializer = new DiagnosticInitializer(new[] { new ElasticDiagnosticListener() });
-            //initializer.Start();
+            options.ExcludeElasticAssemblies();
 
             DiagnosticListener.AllListeners.Subscribe(new ElasticDiagnosticListener());
 

--- a/src/MiniProfiler.Elasticsearch/MiniProfilerBaseOptionsExtensions.cs
+++ b/src/MiniProfiler.Elasticsearch/MiniProfilerBaseOptionsExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics;
+using StackExchange.Profiling.Elasticsearch;
+using StackExchange.Profiling.Internal;
+
+namespace StackExchange.Profiling {
+    public static class MiniProfilerBaseOptionsExtensions {
+        /// <summary>
+        /// Adds Entity Framework Core profiling for MiniProfiler via DiagnosticListener.
+        /// </summary>
+        /// <typeparam name="T">The specific options type to chain with.</typeparam>
+        /// <param name="options">The <see cref="MiniProfilerBaseOptions" /> to register on (just for chaining).</param>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
+        public static T AddElastic<T>(this T options) where T : MiniProfilerBaseOptions {
+            //var initializer = new DiagnosticInitializer(new[] { new ElasticDiagnosticListener() });
+            //initializer.Start();
+
+            DiagnosticListener.AllListeners.Subscribe(new ElasticDiagnosticListener());
+
+            return options;
+        }
+    }
+}

--- a/src/MiniProfiler.Elasticsearch/ProfiledElasticClient.cs
+++ b/src/MiniProfiler.Elasticsearch/ProfiledElasticClient.cs
@@ -10,9 +10,8 @@
         /// Provides base <see cref="ElasticClient"/> with profiling features to current <see cref="MiniProfiler"/> session.
         /// </summary>
         /// <param name="configuration">Instance of <see cref="ConnectionSettings"/>. Its responses will be handled and pushed to <see cref="MiniProfiler"/></param>
-        public ProfiledElasticClient(ConnectionSettings configuration)
-            : base(configuration) {
-            ProfilerUtils.ExcludeElasticsearchAssemblies();
+        public ProfiledElasticClient(ConnectionSettings configuration) : base(configuration) {
+            ProfilerUtils.ExcludeElasticAssemblies();
             ProfilerUtils.ApplyConfigurationSettings(configuration);
             configuration.OnRequestCompleted(apiCallDetails => MiniProfilerElasticsearch.HandleResponse(apiCallDetails));
         }

--- a/src/MiniProfiler.Elasticsearch/ProfiledElasticLowLevelClient.cs
+++ b/src/MiniProfiler.Elasticsearch/ProfiledElasticLowLevelClient.cs
@@ -10,9 +10,8 @@
         /// Provides base <see cref="ElasticLowLevelClient"/> with profiling features to current <see cref="MiniProfiler"/> session.
         /// </summary>
         /// <param name="configuration">Instance of <see cref="ConnectionConfiguration"/>. Its responses will be handled and pushed to <see cref="MiniProfiler"/></param>
-        public ProfiledElasticLowLevelClient(ConnectionConfiguration configuration)
-            : base(configuration) {
-            ProfilerUtils.ExcludeElasticsearchAssemblies();
+        public ProfiledElasticLowLevelClient(ConnectionConfiguration configuration) : base(configuration) {
+            ProfilerUtils.ExcludeElasticAssemblies();
             ProfilerUtils.ApplyConfigurationSettings(configuration);
             configuration.OnRequestCompleted(apiCallDetails => MiniProfilerElasticsearch.HandleResponse(apiCallDetails));
         }

--- a/src/MiniProfiler.Elasticsearch/Utils/ProfilerUtils.cs
+++ b/src/MiniProfiler.Elasticsearch/Utils/ProfilerUtils.cs
@@ -1,7 +1,19 @@
 ﻿namespace StackExchange.Profiling.Elasticsearch.Utils {
+    using System.Collections.Generic;
     using global::Elasticsearch.Net;
+    using StackExchange.Profiling.Internal;
 
     internal static class ProfilerUtils {
+        /// <summary>
+        /// Elasticsearch-related assemblies to exclude from profiling
+        /// </summary>
+        internal static HashSet<string> ExcludedAssemblies { get; } = new HashSet<string> {
+            "Elasticsearch.Net",
+            "Nest",
+            typeof(MiniProfilerElasticsearch).Namespace,
+            typeof(MiniProfilerElasticsearch).Assembly.GetName().Name,
+        };
+
         /// <summary>
         /// Enabling configuration settings prior to receive internal API call timings.
         /// </summary>
@@ -12,12 +24,18 @@
         }
 
         /// <summary>
-        /// Exclude assemblies, so they won't be included into <see cref="MiniProfiler"/> timings' call-stack.
+        /// Excludes Elastic assemblies from passed in <paramref name="options"/>, so they won't be included into <see cref="MiniProfiler"/> timings' call-stack.
         /// </summary>
-        internal static void ExcludeElasticsearchAssemblies() {
-            MiniProfiler.DefaultOptions.ExcludeAssembly("Elasticsearch.Net");
-            MiniProfiler.DefaultOptions.ExcludeAssembly("Nest");
-            MiniProfiler.DefaultOptions.ExcludeAssembly(typeof(MiniProfilerElasticsearch).Assembly.GetName().Name);
+        /// <param name="options"></param>
+        internal static void ExcludeElasticAssemblies(this MiniProfilerBaseOptions options) {
+            foreach (var excludedAssembly in ExcludedAssemblies) {
+                options.ExcludeAssembly(excludedAssembly);
+            }
         }
+
+        /// <summary>
+        /// Excludes Elastic assemblies from <see cref="MiniProfiler.DefaultOptions"/>, so they won't be included into <see cref="MiniProfiler"/> timings' call-stack.
+        /// </summary>
+        internal static void ExcludeElasticAssemblies() => MiniProfiler.DefaultOptions.ExcludeElasticAssemblies();
     }
 }

--- a/tests/MiniProfiler.Elasticsearch.Tests/MiniProfiler.Elasticsearch.Tests.csproj
+++ b/tests/MiniProfiler.Elasticsearch.Tests/MiniProfiler.Elasticsearch.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Provides easy installation via `AddElastic()` on `MiniProfilerBaseOptions` with pushing custom timings into MiniProfiler via DiagnosticListener.

Resolves #12 